### PR TITLE
Fix failure to search companies in admin

### DIFF
--- a/crm/admin.py
+++ b/crm/admin.py
@@ -24,7 +24,7 @@ class SubsidiaryAdmin(ReturnToAppAdmin):
 class CompanyAdmin(ReturnToAppAdmin):
     """Admin model for client companies and suppliers companies"""
     list_display = ("name", "code", "businessOwner", "web")
-    search_fields = ("name", "code", "businessOwner")
+    search_fields = ("name", "code", "businessOwner__name")
     list_filter = ("businessOwner",)
     ordering = ("name",)
 


### PR DESCRIPTION
Tiny bug I found while searching for a company in the admin side. Was causing a Django exception: "Related Field has invalid lookup: icontains".