### PR TITLE
Absolute timesheet

### DIFF
--- a/media/css/pydici.css
+++ b/media/css/pydici.css
@@ -86,6 +86,11 @@ input:focus, textarea:focus { border:1px solid #C54B00; background:#F6F6F6; }
     border: 1px solid #8F6749;
 }
 
+.tablesmall-form-row input.invalid {
+    border: 1px solid red;
+    text: red;
+}
+
 /* To be removed ? Need to be checked */
 ul.errorlist { margin:0 !important; padding:0 !important; }
 .errorlist li { font-size:12px !important; display:block; padding:4px 5px 4px 25px; margin:0 0 3px 0; border:1px solid red; color:white; background:red url(../img/icon_alert.gif) 5px .3em no-repeat; }

--- a/media/css/pydici.css
+++ b/media/css/pydici.css
@@ -75,6 +75,16 @@ input:focus, textarea:focus { border:1px solid #C54B00; background:#F6F6F6; }
 .tablesmall-form-row > tbody > tr > td > input {  background: #F9F9F9; margin: 1px -2px;}
 .tablesmall-form-row input:focus { border:0px; }
 
+.tablesmall-form-row input.timesheet-keyboard {
+    margin: 0;
+    padding: 0;
+    width: 2.5em;
+    text-align: center;
+}
+
+.tablesmall-form-row input.timesheet-keyboard:focus {
+    border: 1px solid #8F6749;
+}
 
 /* To be removed ? Need to be checked */
 ul.errorlist { margin:0 !important; padding:0 !important; }
@@ -128,7 +138,6 @@ div.ui-tooltip {
     max-width: 800px;
     white-space: nowrap;
 }
-
 
 /* Style jquery autocomplete */
 .ui-autocomplete {

--- a/media/css/pydici.css
+++ b/media/css/pydici.css
@@ -71,8 +71,8 @@ input:focus, textarea:focus { border:1px solid #C54B00; background:#F6F6F6; }
 .pydici-mission-timesheet {  border-left:1px solid #DDDDDD;}
 
 /* Small grid like timesheet */
-.tablesmall-form-row > tbody > tr > td { padding:0px; margin:0px; vertical-align: middle;}
-.tablesmall-form-row > tbody > tr > td > input {  background: #F9F9F9; margin: 1px -2px;}
+.tablesmall-form-row td { padding:0px; margin:0px; vertical-align: middle;}
+.tablesmall-form-row input {  background: #F9F9F9; margin: 1px -2px;}
 .tablesmall-form-row input:focus { border:0px; }
 
 .tablesmall-form-row input.timesheet-keyboard {
@@ -86,9 +86,14 @@ input:focus, textarea:focus { border:1px solid #C54B00; background:#F6F6F6; }
     border: 1px solid #8F6749;
 }
 
-.tablesmall-form-row input.invalid {
+.modified, .tablesmall-form-row input.modified {
+    background-color: #ffdba0;
+}
+
+.tablesmall-form-row td.timesheet-error > input.timesheet-keyboard {
     border: 1px solid red;
-    text: red;
+    background-color: #ffeeee;
+    color: red;
 }
 
 /* To be removed ? Need to be checked */

--- a/pydici/pydici_settings.py
+++ b/pydici/pydici_settings.py
@@ -38,6 +38,10 @@ DOCUMENT_PROJECT_BUSINESS_DIR = u"commerce"
 DOCUMENT_PROJECT_DELIVERY_DIR = u"delivery"
 DOCUMENT_PROJECT_INPUT_DIR = u"input"
 
+# can be "cycle" or "keyboard"
+TIMESHEET_INPUT_METHOD = "cycle"
+TIMESHEET_DAY_DURATION = 7
+
 # INCWO_LOG_DIR must point to a dir where the `incwoimport` command can write.
 # It defaults to $PYDICI_PREFIX/incwo-log if not set.
 INCWO_LOG_DIR = os.path.join(PYDICI_ROOTDIR, 'incwo-log')

--- a/staffing/forms.py
+++ b/staffing/forms.py
@@ -300,10 +300,8 @@ class CycleTimesheetField(forms.ChoiceField):
                                         ", ".join(self.TS_VALUES.keys()))
 
 
-class KeyboardTimesheetField(forms.FloatField):
+class KeyboardTimesheetField(forms.Field):
     def __init__(self, *args, **kwargs):
-        kwargs['min_value'] = 0
-        kwargs['max_value'] = settings.TIMESHEET_DAY_DURATION
         kwargs['widget'] = forms.TextInput()
         super(KeyboardTimesheetField, self).__init__(*args, **kwargs)
         self.widget.attrs.setdefault("class", "timesheet-keyboard")

--- a/staffing/forms.py
+++ b/staffing/forms.py
@@ -301,6 +301,8 @@ class CycleTimesheetField(forms.ChoiceField):
 
 
 class KeyboardTimesheetField(forms.Field):
+    day_duration = float(settings.TIMESHEET_DAY_DURATION)
+
     def __init__(self, *args, **kwargs):
         kwargs['widget'] = forms.TextInput()
         super(KeyboardTimesheetField, self).__init__(*args, **kwargs)
@@ -315,7 +317,10 @@ class KeyboardTimesheetField(forms.Field):
             hours = 0
             minutes = 0
         else:
-            total_minutes = int(day_percent * settings.TIMESHEET_DAY_DURATION * 60)
+            # Using round() is important here because int() truncates the
+            # decimal part so int(24.99) returns 24, whereas round(24.99)
+            # returns 25.
+            total_minutes = int(round(day_percent * self.day_duration * 60))
             hours = total_minutes / 60
             minutes = total_minutes % 60
         return '{}:{:02}'.format(hours, minutes)
@@ -328,7 +333,7 @@ class KeyboardTimesheetField(forms.Field):
         except ValueError:
             raise forms.ValidationError('Invalid time string {}'.format(value))
         duration = value_struct[3] + value_struct[4] / 60.0
-        return duration / float(settings.TIMESHEET_DAY_DURATION)
+        return duration / self.day_duration
 
 
 TIMESHEET_FIELD_CLASS_FOR_INPUT_METHOD = {

--- a/staffing/forms.py
+++ b/staffing/forms.py
@@ -306,7 +306,7 @@ class KeyboardTimesheetField(forms.FloatField):
         kwargs['max_value'] = settings.TIMESHEET_DAY_DURATION
         kwargs['widget'] = forms.TextInput()
         super(KeyboardTimesheetField, self).__init__(*args, **kwargs)
-        self.widget.attrs.setdefault('size', 1)  # Reduce default size
+        self.widget.attrs.setdefault("class", "timesheet-keyboard")
 
     def prepare_value(self, day_percent):
         if isinstance(day_percent, types.StringTypes):

--- a/staffing/tests.py
+++ b/staffing/tests.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+
+from staffing.forms import KeyboardTimesheetField
+
+
+class KeyboardTimesheetFieldTest(TestCase):
+    def test_prepare_value(self):
+        data = (
+            # This value is how the percent representing 0:15 is stored in the
+            # DB on the staging server
+            (0.0357142857142857, '0:15'),
+        )
+        field = KeyboardTimesheetField()
+        field.day_duration = 7.0
+        for percent, expected in data:
+            output = field.prepare_value(percent)
+            self.assertEquals(output, expected)
+
+    def test_convert_round_trip(self):
+        data = ('0:15', '1:01', '2:30', '0:01', '8:00')
+        field = KeyboardTimesheetField()
+        field.day_duration = 7.0
+        for input_str in data:
+            percent = field.to_python(input_str)
+            output_str = field.prepare_value(percent)
+            self.assertEquals(output_str, input_str)

--- a/staffing/tests.py
+++ b/staffing/tests.py
@@ -1,26 +1,23 @@
 from django.test import TestCase
 
-from staffing.forms import KeyboardTimesheetField
+from staffing import utils
 
 
-class KeyboardTimesheetFieldTest(TestCase):
+class TimeStringConversionTest(TestCase):
     def test_prepare_value(self):
         data = (
             # This value is how the percent representing 0:15 is stored in the
             # DB on the staging server
             (0.0357142857142857, '0:15'),
         )
-        field = KeyboardTimesheetField()
-        field.day_duration = 7.0
         for percent, expected in data:
-            output = field.prepare_value(percent)
+            output = utils.time_string_for_day_percent(percent, day_duration=7)
             self.assertEquals(output, expected)
 
     def test_convert_round_trip(self):
         data = ('0:15', '1:01', '2:30', '0:01', '8:00')
-        field = KeyboardTimesheetField()
-        field.day_duration = 7.0
+        day_duration = 7
         for input_str in data:
-            percent = field.to_python(input_str)
-            output_str = field.prepare_value(percent)
+            percent = utils.day_percent_for_time_string(input_str, day_duration)
+            output_str = utils.time_string_for_day_percent(percent, day_duration)
             self.assertEquals(output_str, input_str)

--- a/staffing/utils.py
+++ b/staffing/utils.py
@@ -6,9 +6,11 @@ appropriate to live in Staffing models or view
 @author: Sébastien Renard (sebastien.renard@digitalfox.org)
 @license: AGPL v3 or newer (http://www.gnu.org/licenses/agpl-3.0.html)
 """
+import time
 
 from datetime import date, datetime
 
+from django.conf import settings
 from django.db import transaction
 from django.utils import formats
 
@@ -174,3 +176,22 @@ def staffingDates(n=12, format=None, minDate=None):
                           "label": formats.date_format(staffingDate, format="YEAR_MONTH_FORMAT").encode("latin-1"), })
         staffingDate = nextMonth(staffingDate)
     return dates
+
+
+def time_string_for_day_percent(day_percent, day_duration=settings.TIMESHEET_DAY_DURATION):
+    if day_percent is None:
+        hours = 0
+        minutes = 0
+    else:
+        # Using round() is important here because int() truncates the decimal
+        # part so int(24.99) returns 24, whereas round(24.99) returns 25.
+        total_minutes = int(round(day_percent * day_duration * 60))
+        hours = total_minutes / 60
+        minutes = total_minutes % 60
+    return '{}:{:02}'.format(hours, minutes)
+
+
+def day_percent_for_time_string(time_string, day_duration=settings.TIMESHEET_DAY_DURATION):
+    value_struct = time.strptime(time_string, '%H:%M')
+    duration = value_struct[3] + value_struct[4] / 60.0
+    return duration / day_duration

--- a/templates/core/_color_timesheet.html
+++ b/templates/core/_color_timesheet.html
@@ -37,6 +37,10 @@ $(document).ready(function()
             hours = Number(hours);
             minutes = Number(minutes);
             hours += Math.floor(minutes / 60);
+            if (hours >= 24) {
+                $input.parent().addClass('timesheet-error');
+                return;
+            }
             minutes = minutes % 60;
 
             // Left pad with 0

--- a/templates/core/_color_timesheet.html
+++ b/templates/core/_color_timesheet.html
@@ -1,24 +1,28 @@
 {# JS Fragment that color timesheet when user change any value #}
 
 <script type="text/JavaScript">
+function markModified($element) {
+    $element.css("background", "rgba(255,0,0,0.3)");
+    $(".submit-row button").css("background", "rgba(255,0,0,0.2)");
+    $('#readonly-warning').css("background", "rgba(255,0,0,0.2)");
+}
+
 $(document).ready(function()
 {
-    $("input[class=timesheet-cycle]").click(function()
-        {
-            if ($(this).val() == 0) { i="½"; }
-            else if ($(this).val() == "½") { i=1; }
-            else if ($(this).val() == 1)   { i="¼"; }
-            else if ($(this).val() == "¼")   { i="¾"; }
-            else if ($(this).val() == "¾")   { i=0; }
-            $(this).val(i);
-            $(this).css("background", "rgba(255,0,0,0.3)");
-            $(".submit-row button").css("background", "rgba(255,0,0,0.2)");
-            $('#readonly-warning').css("background", "rgba(255,0,0,0.2)");
-        });
-	$("input[name^='lunch_ticket_']").click(function() {
-	        $(this).css("background", "rgba(255,0,0,0.3)");
-	        $(".submit-row button").css("background", "rgba(255,0,0,0.2)");
-	        $('#readonly-warning').css("background", "rgba(255,0,0,0.2)");
+    $("input[class=timesheet-cycle]").click(function() {
+        if ($(this).val() == 0) { i="½"; }
+        else if ($(this).val() == "½") { i=1; }
+        else if ($(this).val() == 1)   { i="¼"; }
+        else if ($(this).val() == "¼")   { i="¾"; }
+        else if ($(this).val() == "¾")   { i=0; }
+        $(this).val(i);
+        markModified($(this));
+    });
+    $("input[class=timesheet-keyboard]").change(function() {
+        markModified($(this));
+    });
+    $("input[name^='lunch_ticket_']").click(function() {
+        markModified($(this));
 	});
 })
 </script>

--- a/templates/core/_color_timesheet.html
+++ b/templates/core/_color_timesheet.html
@@ -3,7 +3,7 @@
 <script type="text/JavaScript">
 $(document).ready(function()
 {
-    $("input[name^='charge_']").click(function()
+    $("input[class=timesheet-cycle]").click(function()
         {
             if ($(this).val() == 0) { i="½"; }
             else if ($(this).val() == "½") { i=1; }

--- a/templates/core/_color_timesheet.html
+++ b/templates/core/_color_timesheet.html
@@ -4,13 +4,13 @@
 $(document).ready(function()
 {
     function markModified($element) {
-        $element.css("background", "rgba(255,0,0,0.3)");
-        $(".submit-row button").css("background", "rgba(255,0,0,0.2)");
-        $('#readonly-warning').css("background", "rgba(255,0,0,0.2)");
+        $element.addClass('modified');
+        $(".submit-row button").addClass('modified');
+        $('#readonly-warning').addClass('modified');
     }
 
     function coerceTime($input) {
-        $input.removeClass('invalid');
+        $input.parent().removeClass('timesheet-error');
         var val = $input.val().trim();
         var HOURS_MINUTES_REGEX = /^(\d+)[h:](\d+)m?/i;
         var HOURS_ONLY_REGEX = /^(\d+)h?$/i;
@@ -32,7 +32,7 @@ $(document).ready(function()
         }
 
         if (hours === null) {
-            $input.addClass('invalid');
+            $input.parent().addClass('timesheet-error');
         } else {
             hours = Number(hours);
             minutes = Number(minutes);

--- a/templates/core/_color_timesheet.html
+++ b/templates/core/_color_timesheet.html
@@ -1,32 +1,17 @@
 {# JS Fragment that color timesheet when user change any value #}
 
 <script type="text/JavaScript">
-function markModified($element) {
-    $element.css("background", "rgba(255,0,0,0.3)");
-    $(".submit-row button").css("background", "rgba(255,0,0,0.2)");
-    $('#readonly-warning').css("background", "rgba(255,0,0,0.2)");
-}
-
 $(document).ready(function()
 {
-    $("input[class=timesheet-cycle]").click(function() {
-        if ($(this).val() == 0) { i="½"; }
-        else if ($(this).val() == "½") { i=1; }
-        else if ($(this).val() == 1)   { i="¼"; }
-        else if ($(this).val() == "¼")   { i="¾"; }
-        else if ($(this).val() == "¾")   { i=0; }
-        $(this).val(i);
-        markModified($(this));
-    });
-    $("input[class=timesheet-keyboard]").change(function() {
-        markModified($(this));
-    });
-    $("input[class=timesheet-keyboard]").focus(function() {
-        $(this).select();
-    });
-    $("input[class=timesheet-keyboard]").blur(function() {
-        $(this).removeClass('invalid');
-        var val = $(this).val().trim();
+    function markModified($element) {
+        $element.css("background", "rgba(255,0,0,0.3)");
+        $(".submit-row button").css("background", "rgba(255,0,0,0.2)");
+        $('#readonly-warning').css("background", "rgba(255,0,0,0.2)");
+    }
+
+    function coerceTime($input) {
+        $input.removeClass('invalid');
+        var val = $input.val().trim();
         var HOURS_MINUTES_REGEX = /^(\d+)[h:](\d+)m?/i;
         var HOURS_ONLY_REGEX = /^(\d+)h?$/i;
         var MINUTES_ONLY_REGEX = /^(\d+)m$/i;
@@ -47,7 +32,7 @@ $(document).ready(function()
         }
 
         if (hours === null) {
-            $(this).addClass('invalid');
+            $input.addClass('invalid');
         } else {
             hours = Number(hours);
             minutes = Number(minutes);
@@ -56,8 +41,25 @@ $(document).ready(function()
 
             // Left pad with 0
             var minutesStr = ('0' + String(minutes)).substr(-2);
-            $(this).val(hours + ':' + minutesStr);
+            $input.val(hours + ':' + minutesStr);
         }
+    }
+
+    $("input[class=timesheet-cycle]").click(function() {
+        if ($(this).val() == 0) { i="½"; }
+        else if ($(this).val() == "½") { i=1; }
+        else if ($(this).val() == 1)   { i="¼"; }
+        else if ($(this).val() == "¼")   { i="¾"; }
+        else if ($(this).val() == "¾")   { i=0; }
+        $(this).val(i);
+        markModified($(this));
+    });
+    $("input[class=timesheet-keyboard]").change(function() {
+        coerceTime($(this));
+        markModified($(this));
+    });
+    $("input[class=timesheet-keyboard]").focus(function() {
+        $(this).select();
     });
     $("input[name^='lunch_ticket_']").click(function() {
         markModified($(this));

--- a/templates/core/_color_timesheet.html
+++ b/templates/core/_color_timesheet.html
@@ -21,6 +21,44 @@ $(document).ready(function()
     $("input[class=timesheet-keyboard]").change(function() {
         markModified($(this));
     });
+    $("input[class=timesheet-keyboard]").focus(function() {
+        $(this).select();
+    });
+    $("input[class=timesheet-keyboard]").blur(function() {
+        $(this).removeClass('invalid');
+        var val = $(this).val().trim();
+        var HOURS_MINUTES_REGEX = /^(\d+)[h:](\d+)m?/i;
+        var HOURS_ONLY_REGEX = /^(\d+)h?$/i;
+        var MINUTES_ONLY_REGEX = /^(\d+)m$/i;
+
+        var hours = null;
+        var minutes;
+
+        var result = HOURS_MINUTES_REGEX.exec(val);
+        if (result) {
+            hours = result[1];
+            minutes = result[2];
+        } else if (result = HOURS_ONLY_REGEX.exec(val)) {
+            hours = result[1];
+            minutes = 0;
+        } else if (result = MINUTES_ONLY_REGEX.exec(val)) {
+            hours = 0;
+            minutes = result[1];
+        }
+
+        if (hours === null) {
+            $(this).addClass('invalid');
+        } else {
+            hours = Number(hours);
+            minutes = Number(minutes);
+            hours += Math.floor(minutes / 60);
+            minutes = minutes % 60;
+
+            // Left pad with 0
+            var minutesStr = ('0' + String(minutes)).substr(-2);
+            $(this).val(hours + ':' + minutesStr);
+        }
+    });
     $("input[name^='lunch_ticket_']").click(function() {
         markModified($(this));
 	});

--- a/templates/core/_color_timesheet.html
+++ b/templates/core/_color_timesheet.html
@@ -62,7 +62,7 @@ $(document).ready(function()
         coerceTime($(this));
         markModified($(this));
     });
-    $("input[class=timesheet-keyboard]").focus(function() {
+    $("input[class=timesheet-keyboard]").click(function() {
         $(this).select();
     });
     $("input[name^='lunch_ticket_']").click(function() {

--- a/templates/staffing/consultant_timesheet.html
+++ b/templates/staffing/consultant_timesheet.html
@@ -36,8 +36,10 @@
 	               <td>{{ field.label|split:" "|last|floatformat:-2 }}</td>
 	               </tr><tr>
                 {% else %}
-	               <td style="text-align:left">{{ field.label }}{{ field.errors }}</td>
-	               <td>{{ field }}</td>
+                   <td style="text-align:left">{{ field.label }}</td>
+                   <td class="{% if field.errors %}timesheet-error{% endif %}">
+                      {{ field }}
+                   </td>
                 {% endif %}
             {% endfor %}
             </tr>


### PR DESCRIPTION
This pull request adds the ability to select how times are entered in the timesheet. The default remains the same: click on the time to cycle between 0, 1/4, 1/2, 3/4 and 1. If `pydici_settings.TIMESHEET_INPUT_METHOD` is set to "keyboard", then the user can enter absolute times by typing them.

Supported syntaxes:
- 1h15 or 1:15 => 1 hour, 15 minutes
- 2 or 2h => 2 hours
- 15m => 15 minutes
