### PR TITLE
Company tab title outside glyphicon span's

### DIFF
--- a/templates/crm/clientcompany_detail.html
+++ b/templates/crm/clientcompany_detail.html
@@ -24,10 +24,10 @@
 <div>
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" id="company-tabs">
-        <li class="active"><a data-toggle="tab" href="#tab-dashboard"><span class="glyphicon glyphicon-home"> {% trans "Dashboard" %}</span></a></li>
-        <li><a data-toggle="tab" href="#tab-leads"><span class="glyphicon glyphicon-list"> {% trans "Leads" %}</span></a></li>
-        <li><a data-toggle="tab" href="#tab-consultants"><span class="glyphicon glyphicon-user"> {% trans "Consultants" %}</span></a></li>
-        <li><a data-toggle="tab" href="#tab-contacts"><span class="glyphicon glyphicon-envelope"> {% trans "Client contacts" %}</span></a></li>
+        <li class="active"><a data-toggle="tab" href="#tab-dashboard"><span class="glyphicon glyphicon-home"></span> {% trans "Dashboard" %}</a></li>
+        <li><a data-toggle="tab" href="#tab-leads"><span class="glyphicon glyphicon-list"></span> {% trans "Leads" %}</a></li>
+        <li><a data-toggle="tab" href="#tab-consultants"><span class="glyphicon glyphicon-user"></span> {% trans "Consultants" %}</a></li>
+        <li><a data-toggle="tab" href="#tab-contacts"><span class="glyphicon glyphicon-envelope"></span> {% trans "Client contacts" %}</a></li>
         <li><a data-toggle="tab" href="#tab-rates-margin" data-tab-url="{% url 'company_rates_margin' company.id %}"><span class="glyphicon glyphicon-shopping-cart"></span> {% trans "Rates and margin" %}</a></li>
         <li><a data-toggle="tab" href="#tab-billing" data-tab-url="{% url 'company_billing' company.id %}"><span class="glyphicon glyphicon-euro"></span> {% trans "Billing" %}</a></li>
         <li><a data-toggle="tab" href="#tab-all-companies"><span class="glyphicon glyphicon-folder-open"></span> {% trans "All companies list" %}</a></li>


### PR DESCRIPTION
Some tab titles are inside of glyphicon span, the text render a bit differently in firefox.
