### PR TITLE
Add stickyness to the submit button in the staffing tab

### DIFF
--- a/media/css/pydici.css
+++ b/media/css/pydici.css
@@ -167,13 +167,19 @@ h5 { font-size:1rem; }
     font-weight: bold;
 }
 
+
+.submit-row.sticky {
+    position: sticky;
+    bottom: 0;
+    padding:0.5rem;
+    border-top: 1px solid #DDDDDD;
+    background-color: white;
+}
+
 /* submit form button sticky for mobile devices */
 @media (max-width: 767px) {
     .submit-row.sticky {
-        position: sticky;
-        bottom: 0;
         padding:0.2rem 0 0.4rem 0;
-        background-color: white;
     }
     .submit-row.sticky > button[type=submit] {
         width: 100%;

--- a/templates/staffing/consultant_staffing.html
+++ b/templates/staffing/consultant_staffing.html
@@ -58,8 +58,8 @@
             {% endfor %}
         </table>
         </div>
-        <br />
-        <div class="submit-row">
+    
+        <div class="submit-row sticky">
             <button type='submit' class="btn btn-primary"><i class="bi bi-save"></i> {% trans 'Save' %}</button>
             <a role="button" class="btn btn-primary button-link"
                href="{% url 'staffing:optimise_pdc' %}?consultant_missions={{ consultant.id }}">


### PR DESCRIPTION
This PR adds stickyness to the submit row on the consultant staffing tab.

It makes this row always visible at the bottom of the screen.

<img width="1034" alt="Capture d’écran 2025-01-10 à 15 53 07" src="https://github.com/user-attachments/assets/1596fc3d-ea68-4ce6-8812-6afb29b255b9" />
