### PR TITLE
Remove pydici notifications regarding if we have planned enough holidays

### DIFF
--- a/people/tasks.py
+++ b/people/tasks.py
@@ -182,15 +182,6 @@ def compute_consultant_tasks(consultant_id):
                                     category=_("timesheet"), priority=overshoot_missions_priority,
                                     link=reverse("people:consultant_home_by_id", args=[consultant.id])+"#tab-timesheet"))
 
-    # too few planned holidays
-    planned_holidays = Staffing.objects.filter(mission__nature="HOLIDAYS", staffing_date__gte=date.today().replace(day=1), consultant=consultant)
-    planned_holidays = planned_holidays.aggregate(Sum("charge"))["charge__sum"] or 0
-    if planned_holidays < 5:
-        planned_holidays_priority = get_task_priority(5 - planned_holidays, (2, 4))
-        tasks.append(ConsultantTask(label=_("Too few holidays planned"), count=planned_holidays,
-                                    category=_("timesheet"), priority=planned_holidays_priority,
-                                    link=reverse("people:consultant_home_by_id", args=[consultant.id])+"#tab-staffing"))
-
     # update cache with computed tasks
     cache.set(CONSULTANT_TASKS_CACHE_KEY % consultant.id, tasks, 24*3600)
 


### PR DESCRIPTION
Pydici didn't manage holidays balances, and don't have enough data to estimate it.

In order to avoid false positive we remove this notification for now