### PR TITLE
Fix broken access control: add missing staffing feature check to 3 mi…

### DIFF
--- a/staffing/views.py
+++ b/staffing/views.py
@@ -398,6 +398,7 @@ def mass_staffing(request):
 
 @pydici_non_public
 @transaction.atomic
+@pydici_feature("staffing_mass")
 def mission_staffing_shift(request, shift, mission_id, ):
     """Shift forecasted mission staffing by "shift" months"""
     #TODO: for now, only 1 month shift is considered.
@@ -888,6 +889,7 @@ def fixed_price_missions_report(request):
 
 
 @pydici_non_public
+@pydici_feature("staffing")
 def deactivate_mission(request, mission_id):
     """Deactivate the given mission. Fragment for htmx call"""
     try:
@@ -2016,6 +2018,7 @@ def mission_update(request):
 
 
 @pydici_non_public
+@pydici_feature("staffing")
 def mission_contacts(request, mission_id):
     """Mission contacts: business, work, administrative
     This views is intended to be called in ajax"""


### PR DESCRIPTION
Following up on my email disclosure.

Three views in `staffing/views.py` mutate a `Mission` while gated by only
`@pydici_non_public` (any internal_access user), whereas their siblings that
mutate the same data require the finer `@pydici_feature(...)`. So an internal
user without the `staffing`/`staffing_mass` feature can archive missions, shift
staffing forecasts, and edit mission contacts.

This adds the feature gate each handler's siblings already use:
- `deactivate_mission` → `@pydici_feature("staffing")` (matches `mission_update`)
- `mission_staffing_shift` → `@pydici_feature("staffing_mass")` (matches `mass_staffing`/`pdc_review`)
- `mission_contacts` → `@pydici_feature("staffing")` (matches `mission_update`)

Minimal — no change for users who already hold the feature.

Separately worth considering (not in this PR, as it touches templates):
`deactivate_mission` and `mission_staffing_shift` change state on GET, so
`@require_POST` would also close the CSRF vector.